### PR TITLE
fix missing cstdint include to allow compilation with gcc 13

### DIFF
--- a/c_src/utils.cc
+++ b/c_src/utils.cc
@@ -12,6 +12,7 @@
 #include <string>
 #include <iostream>
 #include <limits>
+#include <cstdint>
 
 namespace {
 


### PR DESCRIPTION
cfr. `Header dependency changes` in https://gcc.gnu.org/gcc-13/porting_to.html